### PR TITLE
Add minimum USDC reserve for recurring buys

### DIFF
--- a/CoinbaseRecurringBuy/Functions/GetAllocations.cs
+++ b/CoinbaseRecurringBuy/Functions/GetAllocations.cs
@@ -43,8 +43,8 @@ public class GetAllocations(
                 return await MountHttpResponse(req, HttpStatusCode.Forbidden, "Forbidden: You are not authorized to access this resource");
             }
 
-            var allocations = await _allocationService.GetAllAllocationsAsync();
-            return await MountHttpResponse(req, HttpStatusCode.OK, allocations);
+            var settings = await _allocationService.GetSettingsAsync();
+            return await MountHttpResponse(req, HttpStatusCode.OK, settings);
         }
         catch (Exception ex)
         {

--- a/CoinbaseRecurringBuy/Models/Allocations/RecurringBuySettings.cs
+++ b/CoinbaseRecurringBuy/Models/Allocations/RecurringBuySettings.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace CoinbaseRecurringBuy.Models.Allocations;
+
+public class RecurringBuySettings
+{
+    [JsonPropertyName("minimumUsdcBalance")]
+    public decimal MinimumUsdcBalance { get; set; }
+
+    [JsonPropertyName("allocations")]
+    public List<CryptoAllocation> Allocations { get; set; } = [];
+}

--- a/CoinbaseRecurringBuy/Models/Coinbase/GetAccountsResponse.cs
+++ b/CoinbaseRecurringBuy/Models/Coinbase/GetAccountsResponse.cs
@@ -1,0 +1,66 @@
+using System.Text.Json.Serialization;
+
+namespace CoinbaseRecurringBuy.Models.Coinbase;
+
+public class GetAccountsResponse
+{
+    [JsonPropertyName("accounts")]
+    public List<CoinbaseAccount> Accounts { get; set; } = new();
+
+    [JsonPropertyName("has_next")]
+    public bool HasNext { get; set; }
+
+    [JsonPropertyName("cursor")]
+    public string? Cursor { get; set; }
+
+    [JsonPropertyName("size")]
+    public int Size { get; set; }
+}
+
+public class CoinbaseAccount
+{
+    [JsonPropertyName("uuid")]
+    public string Uuid { get; set; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("currency")]
+    public string Currency { get; set; } = string.Empty;
+
+    [JsonPropertyName("available_balance")]
+    public CoinbaseBalance AvailableBalance { get; set; } = new();
+
+    [JsonPropertyName("default")]
+    public bool Default { get; set; }
+
+    [JsonPropertyName("active")]
+    public bool Active { get; set; }
+
+    [JsonPropertyName("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("updated_at")]
+    public DateTime UpdatedAt { get; set; }
+
+    [JsonPropertyName("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyName("ready")]
+    public bool Ready { get; set; }
+
+    [JsonPropertyName("hold")]
+    public CoinbaseBalance? Hold { get; set; }
+}
+
+public class CoinbaseBalance
+{
+    [JsonPropertyName("value")]
+    public string Value { get; set; } = "0";
+
+    [JsonPropertyName("currency")]
+    public string Currency { get; set; } = string.Empty;
+}

--- a/coinbase-allocations-client/src/services/allocationService.ts
+++ b/coinbase-allocations-client/src/services/allocationService.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { AllocationResponse, AllocationUpdateRequest } from '../types/allocation';
+import { AllocationResponse, AllocationUpdateRequest, Allocation } from '../types/allocation';
 import { apiConfig } from '../auth/authConfig';
 
 const getAllocations = async (accessToken: string): Promise<AllocationResponse> => {
@@ -9,7 +9,19 @@ const getAllocations = async (accessToken: string): Promise<AllocationResponse> 
       'x-functions-key': apiConfig.functionKey,
     },
   });
-  return response.data;
+  const data = response.data;
+
+  if (Array.isArray(data)) {
+    return {
+      allocations: data as Allocation[],
+      minimumUsdcBalance: 0,
+    };
+  }
+
+  return {
+    allocations: data.allocations ?? [],
+    minimumUsdcBalance: data.minimumUsdcBalance ?? 0,
+  };
 };
 
 const updateAllocations = async (accessToken: string, allocations: AllocationUpdateRequest): Promise<void> => {

--- a/coinbase-allocations-client/src/types/allocation.ts
+++ b/coinbase-allocations-client/src/types/allocation.ts
@@ -4,6 +4,11 @@ export interface Allocation {
   isActive: boolean;
 }
 
-export interface AllocationResponse extends Array<Allocation> {}
+export interface RecurringBuySettings {
+  allocations: Allocation[];
+  minimumUsdcBalance: number;
+}
 
-export interface AllocationUpdateRequest extends Array<Allocation> {} 
+export type AllocationResponse = RecurringBuySettings;
+
+export type AllocationUpdateRequest = RecurringBuySettings;


### PR DESCRIPTION
## Summary
- add recurring buy settings with minimum USDC balance
- prevent scheduler from spending below the configured reserve
- expose reserve editing UI + API wiring in the allocations client

## Testing
- dotnet build CoinbaseRecurringBuy/CoinbaseRecurringBuy.sln
- npm run build