### PR TITLE
Add minimum USDC balance protection for recurring buys

### DIFF
--- a/CoinbaseRecurringBuy/Functions/CoinbaseRecurringBuyTimer.cs
+++ b/CoinbaseRecurringBuy/Functions/CoinbaseRecurringBuyTimer.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using CoinbaseRecurringBuy.Services;
@@ -13,15 +14,57 @@ public class CoinbaseRecurringBuyTimer(
     public async Task Run([TimerTrigger("%CoinbaseRecurringBuyCronExpression%", RunOnStartup = false)] TimerInfo myTimer)
     {
         logger.LogInformation("Starting recurring buy execution at: {Now}", DateTime.Now);
-    
-        var allocations = await allocationService.GetAllocationsAsync();
-        foreach (var allocation in allocations)
+
+        var allocationSettings = await allocationService.GetAllocationSettingsAsync();
+        var activeAllocations = allocationSettings.Allocations
+            .Where(a => a.IsActive)
+            .ToList();
+
+        if (activeAllocations.Count == 0)
         {
+            logger.LogInformation("No active allocations found. Nothing to execute.");
+            return;
+        }
+
+        decimal availableUsdc;
+        try
+        {
+            availableUsdc = await coinbaseService.GetUsdcBalanceAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to retrieve USDC balance. Skipping this run.");
+            return;
+        }
+
+        var minimumUsdcBalance = allocationSettings.MinimumUsdcBalance;
+        logger.LogInformation("Available USDC balance: {Available}. Configured minimum: {Minimum}.", availableUsdc, minimumUsdcBalance);
+
+        if (availableUsdc <= minimumUsdcBalance)
+        {
+            logger.LogWarning("Available balance is at or below the minimum threshold. No orders will be placed.");
+            return;
+        }
+
+        foreach (var allocation in activeAllocations)
+        {
+            var projectedBalance = availableUsdc - allocation.USDCAmount;
+            if (projectedBalance < minimumUsdcBalance)
+            {
+                logger.LogWarning(
+                    "Skipping order for {Symbol}: executing would reduce USDC balance below the minimum ({Projected} < {Minimum}).",
+                    allocation.Symbol,
+                    projectedBalance,
+                    minimumUsdcBalance);
+                continue;
+            }
+
             try
             {
                 logger.LogInformation("Placing order for {Symbol}: {Amount} USDC", allocation.Symbol, allocation.USDCAmount);
                 await coinbaseService.PlaceMarketOrderAsync(allocation.Symbol, allocation.USDCAmount);
-                logger.LogInformation("Successfully placed order for {Symbol}", allocation.Symbol);
+                availableUsdc = projectedBalance;
+                logger.LogInformation("Successfully placed order for {Symbol}. Remaining available USDC: {Remaining}", allocation.Symbol, availableUsdc);
             }
             catch (Exception ex)
             {

--- a/CoinbaseRecurringBuy/Functions/UpdateAllocations.cs
+++ b/CoinbaseRecurringBuy/Functions/UpdateAllocations.cs
@@ -46,14 +46,18 @@ public class UpdateAllocations(
             }
 
             string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
-            var allocations = JsonSerializer.Deserialize<List<CryptoAllocation>>(requestBody);
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
+            var allocationSettings = JsonSerializer.Deserialize<AllocationSettings>(requestBody, options);
 
-            if (allocations == null)
+            if (allocationSettings?.Allocations == null)
             {
                 return await MountHttpResponse(req, HttpStatusCode.BadRequest, "Invalid allocation data");
             }
 
-            await _allocationService.UpdateAllocationsAsync(allocations);
+            await _allocationService.UpdateAllocationsAsync(allocationSettings);
             
             return await MountHttpResponse(req, HttpStatusCode.OK, new { success = true });
         }

--- a/CoinbaseRecurringBuy/Models/Allocations/AllocationSettings.cs
+++ b/CoinbaseRecurringBuy/Models/Allocations/AllocationSettings.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace CoinbaseRecurringBuy.Models.Allocations;
+
+public class AllocationSettings
+{
+    [JsonPropertyName("minimumUsdcBalance")]
+    public decimal MinimumUsdcBalance { get; set; }
+
+    [JsonPropertyName("allocations")]
+    public List<CryptoAllocation> Allocations { get; set; } = [];
+}

--- a/CoinbaseRecurringBuy/Models/Allocations/AllocationSettingsResponse.cs
+++ b/CoinbaseRecurringBuy/Models/Allocations/AllocationSettingsResponse.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace CoinbaseRecurringBuy.Models.Allocations;
+
+public class AllocationSettingsResponse
+{
+    [JsonPropertyName("minimumUsdcBalance")]
+    public decimal MinimumUsdcBalance { get; set; }
+
+    [JsonPropertyName("allocations")]
+    public List<CryptoAllocation> Allocations { get; set; } = [];
+
+    [JsonPropertyName("currentUsdcBalance")]
+    public decimal? CurrentUsdcBalance { get; set; }
+}

--- a/CoinbaseRecurringBuy/Models/Coinbase/CoinbaseAccount.cs
+++ b/CoinbaseRecurringBuy/Models/Coinbase/CoinbaseAccount.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace CoinbaseRecurringBuy.Models.Coinbase;
+
+public class CoinbaseAccountsResponse
+{
+    [JsonPropertyName("accounts")]
+    public List<CoinbaseAccount> Accounts { get; set; } = [];
+}
+
+public class CoinbaseAccount
+{
+    [JsonPropertyName("currency")]
+    public string Currency { get; set; } = string.Empty;
+
+    [JsonPropertyName("available_balance")]
+    public CoinbaseBalance? AvailableBalance { get; set; }
+}
+
+public class CoinbaseBalance
+{
+    [JsonPropertyName("value")]
+    public string Value { get; set; } = "0";
+
+    [JsonPropertyName("currency")]
+    public string Currency { get; set; } = string.Empty;
+}

--- a/coinbase-allocations-client/src/services/allocationService.ts
+++ b/coinbase-allocations-client/src/services/allocationService.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
-import { AllocationResponse, AllocationUpdateRequest } from '../types/allocation';
+import { AllocationSettings } from '../types/allocation';
 import { apiConfig } from '../auth/authConfig';
 
-const getAllocations = async (accessToken: string): Promise<AllocationResponse> => {
+const getAllocations = async (accessToken: string): Promise<AllocationSettings> => {
   const response = await axios.get(apiConfig.allocationsFetchEndpoint, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -12,8 +12,8 @@ const getAllocations = async (accessToken: string): Promise<AllocationResponse> 
   return response.data;
 };
 
-const updateAllocations = async (accessToken: string, allocations: AllocationUpdateRequest): Promise<void> => {
-  await axios.post(apiConfig.allocationsUpdateEndpoint, allocations, {
+const updateAllocations = async (accessToken: string, settings: AllocationSettings): Promise<void> => {
+  await axios.post(apiConfig.allocationsUpdateEndpoint, settings, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
       'Content-Type': 'application/json',

--- a/coinbase-allocations-client/src/types/allocation.ts
+++ b/coinbase-allocations-client/src/types/allocation.ts
@@ -4,6 +4,8 @@ export interface Allocation {
   isActive: boolean;
 }
 
-export interface AllocationResponse extends Array<Allocation> {}
-
-export interface AllocationUpdateRequest extends Array<Allocation> {} 
+export interface AllocationSettings {
+  minimumUsdcBalance: number;
+  allocations: Allocation[];
+  currentUsdcBalance?: number | null;
+}


### PR DESCRIPTION
## Summary

Adds the ability to configure a minimum USDC balance threshold that must be preserved during recurring buy executions. This prevents the system from exhausting the entire USDC balance and maintains a safety buffer for other transactions.

### Backend Changes
- **New Models**: Added `AllocationSettings`, `AllocationSettingsResponse`, and `CoinbaseAccount` models to support minimum balance configuration and Coinbase account data
- **Service Layer**: 
  - Implemented `GetUsdcBalanceAsync()` in `CoinbaseProService` to retrieve available USDC from Coinbase API
  - Migrated `AllocationService` from array-based storage to `AllocationSettings` object with backward compatibility for legacy format
  - Extracted `PrepareAuthenticatedClient()` helper to reduce code duplication
- **API Endpoints**: Updated to return/accept `AllocationSettings` including minimum balance and current USDC balance
- **Timer Function**: Added pre-execution balance validation to skip orders that would drop balance below minimum threshold

### Frontend Changes
- **UI Components**: Added input field and save button to configure minimum USDC balance threshold
- **Display**: Shows current USDC balance retrieved from Coinbase API
- **Service Layer**: Updated to work with new `AllocationSettings` structure
- **Type Definitions**: Unified allocation types into single `AllocationSettings` interface

### Key Features
- Checks available USDC balance before each recurring buy execution
- Validates each order to ensure it won't drop balance below configured minimum
- Skips orders that would violate the threshold with detailed logging
- Tracks remaining balance across multiple orders in a single execution
- Gracefully handles API failures when retrieving balance
- Backward compatible with existing allocation data

## Test Plan
- [x] Verify minimum balance configuration saves correctly via API
- [x] Verify current USDC balance displays in UI
- [x] Test timer function skips orders when balance is at/below minimum
- [x] Test timer function processes orders when balance is sufficient
- [x] Verify cumulative spending respects minimum across multiple orders
- [x] Test backward compatibility with legacy allocation format
- [x] Verify error handling when Coinbase API balance retrieval fails